### PR TITLE
Resolve parent name

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ contract ExampleContract {
     }
 }
 ```
+### Features and Limitations
+
+One important feature of XAP is its ability to provide resolved addresses for a single name on each EVM compatible chain using the chain ID. This is particularly significant for multisig wallets that may have different addresses on various EVM chains. However, currently, popular clients like ethers.js and Metamask do not support ENSIP-11, which enables EVM compatible chain address resolution, such as mywallet.xap.eth. As a result, it is necessary to use the XAP registry directly to resolve any addresses other than those on the mainnet Ethereum, such as Layer 2s. Once ENSIP-11 gains more widespread support, alternative EVM chains can be used directly via clients such as Ethers.js and Metamask.
 
 ### Security and Audits
 

--- a/contracts/IMutableRegistry.sol
+++ b/contracts/IMutableRegistry.sol
@@ -1,0 +1,38 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface IMutableRegistry{
+
+    // Logged when the owner of a node transfers ownership to a new account.
+    event Transfer(bytes32 indexed name, address owner);
+
+    // Logged when a address is added or updated for a name.
+    event NewAddress(bytes32 indexed name, uint chainId);
+
+    function setApprovalForAll(address operator) external;
+
+    function isApprovedForAll(address account, address operator) external view returns (bool);
+
+    function approve(bytes32 name, address delegate) external;
+
+    function isApprovedFor(address owner, bytes32 name, address delegate) external view returns (bool);
+
+    function register(bytes32 name, address _owner, uint256 chainId, address _address) external;
+
+    function registerWithData(bytes32 name, address _owner, bytes memory contentHash, uint256 chainId, address _address) external;
+
+    function registerAddress(bytes32 name, uint256 chainId, address _address) external;
+
+    function setOwner(bytes32 name, address _address) external;
+
+    function setContentHash(bytes32 name, bytes memory _contentHash) external;
+
+    function setTextRecord(bytes32 name, string memory key, string memory value) external;
+
+    function resolveAddress(bytes32 name, uint256 chainId) external view returns (address);
+
+    function getOwner(bytes32 name) external view returns (address);
+
+    function available(bytes32 name) external view returns (bool);
+
+}

--- a/contracts/IMutableRegistry.sol
+++ b/contracts/IMutableRegistry.sol
@@ -4,35 +4,39 @@ pragma solidity ^0.8.18;
 interface IMutableRegistry{
 
     // Logged when the owner of a node transfers ownership to a new account.
-    event Transfer(bytes32 indexed name, address owner);
+    event Transfer(bytes  indexed name, address owner);
 
     // Logged when a address is added or updated for a name.
-    event NewAddress(bytes32 indexed name, uint chainId);
+    event NewAddress(bytes indexed name, uint chainId);
 
     function setApprovalForAll(address operator) external;
 
     function isApprovedForAll(address account, address operator) external view returns (bool);
 
-    function approve(bytes32 name, address delegate) external;
+    function approve(bytes memory name, address delegate) external;
 
-    function isApprovedFor(address owner, bytes32 name, address delegate) external view returns (bool);
+    function isApprovedFor(address owner, bytes memory name, address delegate) external view returns (bool);
 
-    function register(bytes32 name, address _owner, uint256 chainId, address _address) external;
+    function register(bytes memory name, address _owner, uint256 chainId, address _address) external;
 
-    function registerWithData(bytes32 name, address _owner, bytes memory contentHash, uint256 chainId, address _address) external;
+    function registerWithData(bytes memory name, address _owner, bytes memory contentHash, uint256 chainId, address _address) external;
 
-    function registerAddress(bytes32 name, uint256 chainId, address _address) external;
+    function registerAddress(bytes memory name, uint256 chainId, address _address) external;
 
-    function setOwner(bytes32 name, address _address) external;
+    function setOwner(bytes memory name, address _address) external;
 
-    function setContentHash(bytes32 name, bytes memory _contentHash) external;
+    function setContentHash(bytes memory name, bytes memory _contentHash) external;
 
-    function setTextRecord(bytes32 name, string memory key, string memory value) external;
+    function setTextRecord(bytes memory name, string memory key, string memory value) external;
 
-    function resolveAddress(bytes32 name, uint256 chainId) external view returns (address);
+    function resolveAddress(bytes memory name, uint256 chainId) external view returns (address);
 
-    function getOwner(bytes32 name) external view returns (address);
+    function getOwner(bytes memory name) external view returns (address);
 
-    function available(bytes32 name) external view returns (bool);
+    function getContentHash (bytes memory name) external view returns (bytes memory);
+
+    function getTextRecord (bytes memory name, string memory key) external view returns (string memory);
+
+    function available(bytes memory name) external view returns (bool);
 
 }

--- a/contracts/IXAPResolver.sol
+++ b/contracts/IXAPResolver.sol
@@ -2,10 +2,15 @@
 pragma solidity ^0.8.18;
 
 import {IXAPRegistry} from "./IXAPRegistry.sol";
+import {IMutableRegistry} from "./IMutableRegistry.sol";
 
 interface IXAPResolver {
 
     function xap() external view returns (IXAPRegistry);
+
+    function mutableRegistry() external view returns (IMutableRegistry);
+
+    function parentName() external view returns (bytes memory);
 
     function resolve(bytes memory name, bytes memory data)
         external

--- a/contracts/IXAPResolver.sol
+++ b/contracts/IXAPResolver.sol
@@ -12,6 +12,8 @@ interface IXAPResolver {
 
     function parentName() external view returns (bytes memory);
 
+    function setParentName(bytes memory name) external;
+
     function resolve(bytes memory name, bytes memory data)
         external
         view

--- a/contracts/MutableRegistry.sol
+++ b/contracts/MutableRegistry.sol
@@ -1,0 +1,301 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {IMutableRegistry} from "./IMutableRegistry.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {Controllable} from "./Controllable.sol";
+
+error Unauthorized(bytes32 name);
+error NotAvailable(bytes32 name);
+error AccountImmutable(bytes32 name, uint256 chainId, address account);
+error CannotSetOwnerToZeroAddress();
+error MustHaveNonZeroAddress();
+error ImmutableRecord(bytes32 name, uint256 chainId, uint96 addressData);
+error CannotDelegateToSelf();
+
+contract MutableRegistry is IMutableRegistry, ERC165, Controllable{
+
+    struct Record {
+
+        address owner;
+        // A mapping of chain ids to addresses and data (stored as a single uint256). 
+        mapping(uint256 chainId => address addr) addresses;
+        mapping(string key => string value) textRecords;
+        bytes contentHash;
+
+    }
+
+    /**
+     * A mapping of names to records.
+     */
+    mapping(bytes32 name => Record record) private records;
+
+    /**
+     * A mapping of operators. An address that is authorized for an address
+     * may make any changes to the name that the owner could, but may not update
+     * the set of authorisations.
+     */
+    mapping(address owner => address operator) private _operatorApprovals;
+
+    /**
+     * A mapping of delegates. The delegate that is set by an owner
+     * for a name may make changes to the name's resolver, but may not update
+     * the set of token approvals.
+     */
+    mapping(address owner => mapping(bytes32 name => address delegate)) private _tokenApprovals; 
+
+    // Logged when an operator is added or removed.
+    event ApprovalForAll(
+        address indexed owner,
+        address indexed operator
+    );
+
+    // Logged when a delegate is approved or  an approval is revoked.
+    event Approved(
+        address owner,
+        bytes32 indexed name,
+        address indexed delegate
+    );
+
+    /**
+     * @dev Allows for approving a single operator.
+     */
+    function setApprovalForAll(address operator) external {
+
+        if(msg.sender == operator){
+            revert CannotDelegateToSelf();         
+        }
+
+        _operatorApprovals[msg.sender] = operator;
+        emit ApprovalForAll(msg.sender, operator);
+    }
+
+    /**
+     * @dev Check to see if the operator is approved for all.
+     */
+    function isApprovedForAll(address account, address operator)
+        public
+        view
+        returns (bool)
+    {
+        return _operatorApprovals[account] == operator;
+    }
+
+    /**
+     * @dev Approve a delegate to be able to updated records on a name.
+     */
+    function approve(bytes32 name, address delegate) external {
+
+        if(msg.sender == delegate){
+            revert CannotDelegateToSelf();         
+        }
+
+        _tokenApprovals[msg.sender][name] = delegate;
+        emit Approved(msg.sender, name, delegate);
+    }
+
+    /**
+     * @dev Check to see if the delegate has been approved by the owner for the name.
+     */
+    function isApprovedFor(address owner, bytes32 name, address delegate)
+        public
+        view
+        returns (bool)
+    {
+        return _tokenApprovals[owner][name] == delegate;
+    }
+
+    /**
+    * @dev The function registers a name with the owner address.
+    * @param name The name to be registered.
+    * @param _owner The account to be registered as the owner of the name.
+    * @param chainId The chainId on which the name will be registered.
+    * @param _address The resolved account for a specific chainId.
+     */
+
+    function register(
+        bytes32 name, 
+        address _owner, 
+        uint256 chainId, 
+        address _address
+    ) external onlyController{
+
+        // Check to make sure the name has not already been registered. 
+        address oldOwner = records[name].owner; 
+
+        if (oldOwner != address(0)){
+            revert NotAvailable(name);
+        }
+
+        records[name].owner = _owner;
+        records[name].addresses[chainId] = _address;
+
+    }
+
+    /**
+    * @dev The function registers a name with the owner address.
+    * @param name The name to be registered.
+    * @param _owner The account to be registered as the owner of the name.
+    * @param contentHash The content hash of the name.
+    * @param chainId The chainId on which the name will be registered.
+    * @param _address The resolved account for a specific chainId.
+     */
+
+    function registerWithData(
+        bytes32 name, 
+        address _owner, 
+        bytes memory contentHash, 
+        uint256 chainId, 
+        address _address
+    ) external onlyController{
+
+        // Check to make sure the name has not already been registered. 
+        address oldOwner = records[name].owner; 
+        
+        if (oldOwner != address(0)){
+            revert NotAvailable(name);
+        }
+
+        records[name].owner = _owner;
+        records[name].addresses[chainId] = _address;
+        records[name].contentHash = contentHash;
+
+    }
+
+    /**
+    * @dev The function registers an address with a name on the specified chain.
+    * @param name The name to be registered.
+    * @param chainId The chainId on which the address will be registered.
+    * @param _address The account to be registered with the name.
+    */ 
+    function registerAddress(bytes32 name, uint256 chainId, address _address) external onlyAuthorized(name){
+
+        // Make sure the address is not the 0 address. 
+        if(_address == address(0)){
+            revert MustHaveNonZeroAddress();
+        }
+        records[name].addresses[chainId] = _address;
+
+    }
+
+
+    /**
+    * @dev The function sets the owner of a name.
+    * @param name The name for which the owner will be set.
+    * @param _address The address to be set as the owner of the name.
+    */    
+
+    function setOwner(bytes32 name, address _address) external onlyAuthorized(name){
+
+        // Make sure the address is not the zero address.
+        if (_address == address(0)){
+            revert CannotSetOwnerToZeroAddress();
+        }
+
+        records[name].owner = _address;
+
+    }
+
+    /**
+    * @dev The function sets the account data.
+    * @param name The name for which the owner will be set.
+    * @param _contentHash The auxiliary data of the account.
+    */    
+
+    function setContentHash(bytes32 name, bytes memory _contentHash) external onlyAuthorized(name){
+
+        records[name].contentHash = _contentHash;
+
+    }
+
+    /**
+    * @dev The function sets the account data.
+    * @param name The name for which the owner will be set.
+    * @param key The key of the text record.
+    * @param value The value of the text record.
+    */    
+
+    function setTextRecord(bytes32 name, string memory key, string memory value) external onlyAuthorized(name){
+
+        records[name].textRecords[key] = value;
+
+    }
+    
+    /**
+    * @dev The function resolves an address associated with a name on a specific chain.
+    * @param name The name for which the address will be resolved.
+    * @param chainId The chainId on which the address is registered.
+    * @return The address associated with the name on the specified chain.
+    */
+
+    function resolveAddress(bytes32 name, uint256 chainId) public view returns (address){
+
+        // resolve the address and return the account.
+        // Note: if the address is not set the account will be the zero address.
+        address _address = records[name].addresses[chainId];
+        return _address;
+
+    }
+
+    /**
+    * @dev The function returns the owner of a name.
+    * @param name The name for which the owner will be returned.
+    * @return The owner of the name.
+    */
+
+    function getOwner(bytes32 name) public view returns (address){
+
+        // Note: If the name has not been registered the owner will be the zero address.
+        address _owner = records[name].owner; 
+        return _owner;
+
+    }
+
+    /**
+    * @dev The function checks if a name is available for registration.
+    * @param name The name to check availability for.
+    * @return Boolean indicating whether the name is available for registration.
+    */
+
+    function available(bytes32 name) external view returns (bool){
+
+        address _owner = records[name].owner; 
+        return _owner == address(0);
+
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return
+            interfaceId == type(IMutableRegistry).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    //Check whether the sender is authorized to access the function.
+    modifier onlyAuthorized(bytes32 name){
+
+        if (isAuthorized(name)){
+            revert Unauthorized(name);
+        }
+        _;
+
+    }
+
+    function isAuthorized(bytes32 name) internal view  returns (bool) {
+
+        address owner = getOwner(name);
+
+        return owner == msg.sender || isApprovedForAll(owner, msg.sender) || 
+            isApprovedFor(owner, name, msg.sender);
+    }
+
+}

--- a/contracts/XAPRegistry.sol
+++ b/contracts/XAPRegistry.sol
@@ -326,9 +326,12 @@ contract XAPRegistry is IXAPRegistry, ERC165, Controllable {
     //Check whether the sender is authorized to access the function.
     modifier onlyAuthorized(bytes32 name){
 
-        if (isAuthorized(name)){
+        // If the sender is not! authorized, revert.
+        if (!isAuthorized(name)){
             revert Unauthorized(name);
         }
+
+
         _;
 
     }
@@ -337,6 +340,7 @@ contract XAPRegistry is IXAPRegistry, ERC165, Controllable {
 
         address owner = getOwner(name);
 
+        // If the sender is the owner or is approved for all or is approved for the name, return true.
         return owner == msg.sender || isApprovedForAll(owner, msg.sender) || 
             isApprovedFor(owner, name, msg.sender);
     }

--- a/test/XAPRegistry.t.sol
+++ b/test/XAPRegistry.t.sol
@@ -87,13 +87,13 @@ contract XAPRegistryTest is Test{
     // Test the registerAddress function.
     function test_004____registerAddress_____________RegisterAXAPAddress() public {
 
-        // The current caller 'account' has been set as a controller so it can register a subname.
-        // Set up a XAP address.
-        xap.registerAddress(bytes10(bytes("addr-two")), 60, account2); 
-        assertEq(xap.resolveAddress(bytes10(bytes("addr-two")), 60), account2);
+        // Set up a XAP account and second address.
+        xap.register(bytes10(bytes("addr-two")), account, 77, account2); 
+        xap.registerAddress(bytes10(bytes("addr-two")), 60, account); 
+        assertEq(xap.resolveAddress(bytes10(bytes("addr-two")), 60), account);
 
         // Expect a revert with custom error message.
-        vm.expectRevert( abi.encodeWithSelector(AccountImmutable.selector, bytes10(bytes("addr-two")), 60, account2)); 
+        vm.expectRevert( abi.encodeWithSelector(AccountImmutable.selector, bytes10(bytes("addr-two")), 60, account)); 
         xap.registerAddress(bytes10(bytes("addr-two")), 60, account2); 
 
     }
@@ -102,6 +102,8 @@ contract XAPRegistryTest is Test{
     function test_005____registerAddressWithData_____RegisterAXAPAddressWithAccountData() public {
 
         // Set up a XAP address.
+        xap.register(bytes10(bytes("addr-two")), account, 77, account2);
+        // Add an address to the XAP address.
         xap.registerAddressWithData(bytes10(bytes("addr-two")), 60, account2, uint96(2334556)); 
         (address resolvedAddress, uint96 resolvedData) = 
             xap.resolveAddressWithData(bytes10(bytes("addr-two")), 60);
@@ -119,8 +121,8 @@ contract XAPRegistryTest is Test{
     function test_006____setOwner____________________OwnerIsSetCorrectly() public {
 
         // Set up a XAP address.
-        xap.register(bytes10(bytes("addr-two")), account2, 60, account2); 
-        assertEq(xap.getOwner(bytes10(bytes("addr-two"))), account2);
+        xap.register(bytes10(bytes("addr-two")), account, 60, account2); 
+        assertEq(xap.getOwner(bytes10(bytes("addr-two"))), account);
 
         // Set the owner of the subname.
         xap.setOwner(bytes10(bytes("addr-two")), account);
@@ -134,8 +136,8 @@ contract XAPRegistryTest is Test{
     function test_007____setAccountData______________AccountDataIsSetCorrectly() public {
 
         // Set up a XAP address.
-        xap.register(bytes10(bytes("addr-two")), account2, 60, account2); 
-        assertEq(xap.getOwner(bytes10(bytes("addr-two"))), account2);
+        xap.register(bytes10(bytes("addr-two")), account, 60, account2); 
+        assertEq(xap.getOwner(bytes10(bytes("addr-two"))), account);
 
         // Set the owner of the subname.
         xap.setAccountData(bytes10(bytes("addr-two")), uint96(2334556));
@@ -183,8 +185,8 @@ contract XAPRegistryTest is Test{
     function test_012____getOwnerWithData____________OwnerAndDataAreRetrievedCorrectly() public {
 
         // Set up a XAP address.
-        xap.register(bytes10(bytes("addr-two")), account2, 60, account2); 
-        assertEq(xap.getOwner(bytes10(bytes("addr-two"))), account2);
+        xap.register(bytes10(bytes("addr-two")), account, 60, account2); 
+        assertEq(xap.getOwner(bytes10(bytes("addr-two"))), account);
 
         // Set the address data of the name.
         xap.setAccountData(bytes10(bytes("addr-two")), uint96(2334556));
@@ -192,7 +194,7 @@ contract XAPRegistryTest is Test{
         // Check to make sure the address data is correct.
         (address resolvedOwner, uint96 resolvedData) = 
             xap.getOwnerWithData(bytes10(bytes("addr-two")));
-        assertEq(resolvedOwner, account2);
+        assertEq(resolvedOwner, account);
         assertEq(resolvedData, uint96(2334556));
 
     }

--- a/test/XAPResolver.t.sol
+++ b/test/XAPResolver.t.sol
@@ -35,7 +35,7 @@ contract XAPResolverTest is Test{
         xap = new XAPRegistry();
 
         // Deploy the XAPResolver.
-        resolver = new XAPResolver(xap);
+        resolver = new XAPResolver(xap,bytes("\x03xap\x03eth\x00"));
 
         // Set up a XAP address.
         xap.setController(account, true);

--- a/test/XAPResolver.t.sol
+++ b/test/XAPResolver.t.sol
@@ -70,7 +70,19 @@ contract XAPResolverTest is Test{
         assertEq(address(bytes20(resolvedAddress)), account2);
 
     }
-    function test_002____resolve_addr________________ResolveAnXAPAdressAsENSSubname() public {
+    function test_002____resolve_addr________________ResolveAnRootAddressXAPETHwithNoChainId() public {
+
+        // Check that the resolver can resolve the address.
+        (bytes memory resolvedAddress, ) = 
+            resolver.resolve(bytes("\x03xap\x03eth\x00"), 
+                abi.encodeWithSelector(bytes4(0x3b3b57de), bytes32(0)));
+
+
+        // Check that the address is correct.
+        assertEq(address(bytes20(resolvedAddress)), account2);
+
+    }
+    function test_003____resolve_addr________________ResolveAnXAPAdressAsENSSubname() public {
 
         // Check that the resolver can resolve the address.
         (bytes memory resolvedAddress, ) = 
@@ -83,7 +95,7 @@ contract XAPResolverTest is Test{
 
     }
 
-    function test_003____resolve_addr________________ResolveAnXAPAddressWithChainId42161AsENSSubname() public {
+    function test_004____resolve_addr________________ResolveAnXAPAddressWithChainId42161AsENSSubname() public {
 
         xap.registerWithData(bytes32(bytes("abc-driver")), account, 100, 42161, account2, 200); 
         assertEq(xap.resolveAddress(bytes32(bytes("abc-driver")), 42161), account2);
@@ -97,7 +109,7 @@ contract XAPResolverTest is Test{
 
     }
 
-    function test_004____resolve_text________________ResolveTheTextRecordOfTheRootXAPETH() public {
+    function test_005____resolve_text________________ResolveTheTextRecordOfTheRootXAPETH() public {
 
         // Check that the resolver can resolve the address.
         (bytes memory resolvedTextRecord, ) = 
@@ -109,7 +121,7 @@ contract XAPResolverTest is Test{
         assertTrue( equalStrings(string(resolvedTextRecord), "test text record value"));
     }
 
-    function test_005____resolve_text________________ResolveTheAddressDataOfAXAPAdress() public {
+    function test_006____resolve_text________________ResolveTheAddressDataOfAXAPAdress() public {
 
         // Check that the resolver can resolve the address.
         (bytes memory resolvedAddressData, ) = 
@@ -121,7 +133,7 @@ contract XAPResolverTest is Test{
         assertEq(uint96(bytes12(resolvedAddressData)), 200);
     }
 
-    function test_006____resolve_text________________ResolveTheAddressDataOfAXAPAdressChainId42161() public {
+    function test_007____resolve_text________________ResolveTheAddressDataOfAXAPAdressChainId42161() public {
 
         xap.registerWithData(bytes32(bytes("abc-driver")), account, 100, 42161, account2, 200); 
         assertEq(xap.resolveAddress(bytes32(bytes("abc-driver")), 42161), account2);
@@ -135,7 +147,7 @@ contract XAPResolverTest is Test{
         // Check that the address is correct.
         assertEq(uint96(bytes12(resolvedAddressData)), 200);
     }
-    function test_007____resolve_contenthash_________ResolveTheContentHashOfAXAPAdress() public {
+    function test_008____resolve_contenthash_________ResolveTheContentHashOfAXAPAdress() public {
 
         // Check that the resolver can resolve the address.
         (bytes memory resolvedContentHash, ) = 
@@ -158,7 +170,7 @@ contract XAPResolverTest is Test{
         assertEq(areEqual, true);
     }    
 
-    function test_008____resolve_contenthash_________ResolveTheContentHashOfRootXAPETH() public {
+    function test_009____resolve_contenthash_________ResolveTheContentHashOfRootXAPETH() public {
 
         // Check that the resolver can resolve the address.
         (bytes memory resolvedContentHash, ) = 
@@ -170,7 +182,7 @@ contract XAPResolverTest is Test{
     }
 
     // Test the supportsInterface function.
-    function test_009____supportsInterface___________SupportsCorrectInterfaces() public {
+    function test_010____supportsInterface___________SupportsCorrectInterfaces() public {
 
         // Check for the ISubnameWrapper interface.  
         assertEq(resolver.supportsInterface(type(IXAPResolver).interfaceId), true);

--- a/test/XAPResolver.t.sol
+++ b/test/XAPResolver.t.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
 import "contracts/XAPRegistry.sol";
-import "contracts/IXAPRegistry.sol";
 import "contracts/IXAPResolver.sol";
 import "contracts/XAPResolver.sol";
+import {MutableRegistry} from "contracts/MutableRegistry.sol";
 import "contracts/mocks/USDOracleMock.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 
@@ -17,6 +17,7 @@ contract XAPResolverTest is Test{
 
     XAPRegistry xap; 
     XAPResolver resolver;
+    MutableRegistry mutableRegistry;
 
     function setUp() public {
 
@@ -28,14 +29,23 @@ contract XAPResolverTest is Test{
         vm.startPrank(account);
         vm.deal(account, 100000000000000000000);
 
-        // Deploy the oracle mock up.
-        USDOracleMock usdOracle = new USDOracleMock();
-
         // Deploy the XAPRegistry.
         xap = new XAPRegistry();
 
+        mutableRegistry = new MutableRegistry();
+
+        mutableRegistry.setController(account, true);
+
+        // Register xap.eth in the mutable registry so that the registrar can return records
+        // for the parent name xap.eth. 
+        mutableRegistry.register(bytes("\x03xap\x03eth\x00"), account, 1, account2);
+
+        // Set up a text record for xap.eth
+        mutableRegistry.setTextRecord(bytes("\x03xap\x03eth\x00"), "test-text-record", "test text record value");
+        mutableRegistry.setContentHash(bytes("\x03xap\x03eth\x00"), bytes("test content hash value"));
+
         // Deploy the XAPResolver.
-        resolver = new XAPResolver(xap,bytes("\x03xap\x03eth\x00"));
+        resolver = new XAPResolver(xap, mutableRegistry, bytes("\x03xap\x03eth\x00"));
 
         // Set up a XAP address.
         xap.setController(account, true);
@@ -48,7 +58,19 @@ contract XAPResolverTest is Test{
     function test2000______________________________XAP_RESOLVER_______________________________() public {}
     function test3000_________________________________________________________________________() public {}
 
-    function test_001____resolve_addr________________ResolveAnXAPAdressAsENSSubname() public {
+    function test_001____resolve_addr________________ResolveAnRootAddressXAPETH() public {
+
+        // Check that the resolver can resolve the address.
+        (bytes memory resolvedAddress, ) = 
+            resolver.resolve(bytes("\x03xap\x03eth\x00"), 
+                abi.encodeWithSelector(bytes4(0xf1cb7e06), bytes32(0), uint256(60)));
+
+
+        // Check that the address is correct.
+        assertEq(address(bytes20(resolvedAddress)), account2);
+
+    }
+    function test_002____resolve_addr________________ResolveAnXAPAdressAsENSSubname() public {
 
         // Check that the resolver can resolve the address.
         (bytes memory resolvedAddress, ) = 
@@ -61,7 +83,7 @@ contract XAPResolverTest is Test{
 
     }
 
-    function test_002____resolve_addr________________ResolveAnXAPAddressWithChainId42161AsENSSubname() public {
+    function test_003____resolve_addr________________ResolveAnXAPAddressWithChainId42161AsENSSubname() public {
 
         xap.registerWithData(bytes32(bytes("abc-driver")), account, 100, 42161, account2, 200); 
         assertEq(xap.resolveAddress(bytes32(bytes("abc-driver")), 42161), account2);
@@ -75,7 +97,19 @@ contract XAPResolverTest is Test{
 
     }
 
-    function test_003____resolve_text________________ResolveTheAddressDataOfAXAPAdress() public {
+    function test_004____resolve_text________________ResolveTheTextRecordOfTheRootXAPETH() public {
+
+        // Check that the resolver can resolve the address.
+        (bytes memory resolvedTextRecord, ) = 
+            resolver.resolve(bytes("\x03xap\x03eth\x00"), 
+                abi.encodeWithSelector(bytes4(0x59d1d43c), bytes32(0), "test-text-record"));
+
+    
+        // Check that the address is correct.
+        assertTrue( equalStrings(string(resolvedTextRecord), "test text record value"));
+    }
+
+    function test_005____resolve_text________________ResolveTheAddressDataOfAXAPAdress() public {
 
         // Check that the resolver can resolve the address.
         (bytes memory resolvedAddressData, ) = 
@@ -87,7 +121,7 @@ contract XAPResolverTest is Test{
         assertEq(uint96(bytes12(resolvedAddressData)), 200);
     }
 
-    function test_004____resolve_text________________ResolveTheAddressDataOfAXAPAdressChainId42161() public {
+    function test_006____resolve_text________________ResolveTheAddressDataOfAXAPAdressChainId42161() public {
 
         xap.registerWithData(bytes32(bytes("abc-driver")), account, 100, 42161, account2, 200); 
         assertEq(xap.resolveAddress(bytes32(bytes("abc-driver")), 42161), account2);
@@ -101,7 +135,7 @@ contract XAPResolverTest is Test{
         // Check that the address is correct.
         assertEq(uint96(bytes12(resolvedAddressData)), 200);
     }
-    function test_005____resolve_contenthash_________ResolveTheContentHashOfAXAPAdress() public {
+    function test_007____resolve_contenthash_________ResolveTheContentHashOfAXAPAdress() public {
 
         // Check that the resolver can resolve the address.
         (bytes memory resolvedContentHash, ) = 
@@ -123,9 +157,20 @@ contract XAPResolverTest is Test{
         bool areEqual = equalStrings(string(resolvedContentHash), outString);
         assertEq(areEqual, true);
     }    
-    
+
+    function test_008____resolve_contenthash_________ResolveTheContentHashOfRootXAPETH() public {
+
+        // Check that the resolver can resolve the address.
+        (bytes memory resolvedContentHash, ) = 
+        resolver.resolve(bytes("\x03xap\x03eth\x00"), 
+            abi.encodeWithSelector(bytes4(0xbc1c58d1), bytes32(0)));
+
+        // Check that the address is correct.
+        assertTrue( equalStrings(string(resolvedContentHash), "test content hash value"));
+    }
+
     // Test the supportsInterface function.
-    function test_006____supportsInterface___________SupportsCorrectInterfaces() public {
+    function test_009____supportsInterface___________SupportsCorrectInterfaces() public {
 
         // Check for the ISubnameWrapper interface.  
         assertEq(resolver.supportsInterface(type(IXAPResolver).interfaceId), true);


### PR DESCRIPTION
To ensure proper wildcard resolution, it is essential to use the same resolver contract to resolve both the subnames and the parent name. However, XAP names are immutable, and the parent-level name, such as XAP.eth, should be mutable to allow for necessary updates. This PR introduces a new registry type, MutableRegistry, which will only be used for the parent-level name, e.g. XAP.eth. The changes include updates to resolve the parent-level name, bug fixes, and new tests.